### PR TITLE
Fix undefined index 'message' on bad request exception factory

### DIFF
--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -17,7 +17,7 @@ class BadRequestException extends MoovlyException
         'server: %s'
     ;
 
-    public function __construct(string $reason)
+    public function __construct(?string $reason)
     {
         parent::__construct(sprintf(self::MESSAGE, $reason), self::CODE);
     }

--- a/src/Factory/ExceptionFactory.php
+++ b/src/Factory/ExceptionFactory.php
@@ -30,7 +30,7 @@ class ExceptionFactory
 
         $message = null;
 
-        if (in_array('message', $APIResponse)) {
+        if (array_key_exists('message', $APIResponse)) {
             $message = $APIResponse['message'];
         }
 


### PR DESCRIPTION
Checking for a message key with `in_array()` will return `true` even if the key is not set.

Example response that causes the error when a bad request is peformed:

```
$APIResponse = [
    'error' => 'Unknown object:0',
    'code' => 0,
]
```