### PR TITLE
Add renders to project factory

### DIFF
--- a/src/Factory/ObjectFactory.php
+++ b/src/Factory/ObjectFactory.php
@@ -30,14 +30,12 @@ class ObjectFactory
             ->setType($response['type'])
             ->setLabel($response['metadata']['label'])
             ->setDescription($response['metadata']['description'])
-            ->setThumbnailPath($response['metadata']['thumb'])
-            ->setTags($response['metadata']['tags'])
-            ->setAlpha($response['metadata']['alpha'])
+            ->setThumbnailPath($response['metadata']['thumb'] ?? '')
+            ->setTags($response['metadata']['tags'] ?? [])
+            ->setAlpha($response['metadata']['alpha'] ?? false)
             ->setStatus($response['status'])
         ;
 
         return $object;
     }
-
-
 }

--- a/src/Factory/ProjectFactory.php
+++ b/src/Factory/ProjectFactory.php
@@ -19,11 +19,14 @@ class ProjectFactory
     {
         $project = new Project();
 
+        $renders = RenderFactory::createFromAPIResponse($response['renders']);
+
         $project
             ->setId($response['id'])
             ->setLabel($response['label'])
             ->setDescription($response['description'])
             ->setThumbnailPath($response['thumb'])
+            ->setRenders($renders)
             ->setArchived($response['archived'])
             ->setPending($response['pending'])
             ->setCreatedAt(new \DateTimeImmutable($response['created_at']))

--- a/src/Factory/RenderFactory.php
+++ b/src/Factory/RenderFactory.php
@@ -20,6 +20,10 @@ class RenderFactory
         $results = [];
 
         foreach ($renders as $render) {
+            if (is_null($render)) {
+                continue;
+            }
+
             $results[] = (new Render())
                 ->setId($render['id'])
                 ->setState($render['state'])

--- a/src/Factory/RenderFactory.php
+++ b/src/Factory/RenderFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Moovly\SDK\Factory;
+
+use Moovly\SDK\Model\Render;
+
+/**
+ * Class RenderFactory
+ * @package Moovly\SDK\Factory
+ */
+class RenderFactory
+{
+    /**
+     * @param array  $renders
+     *
+     * @return Render[]
+     */
+    public static function createFromAPIResponse(array $renders) : array
+    {
+        $results = [];
+
+        foreach ($renders as $render) {
+            $results[] = (new Render())
+                ->setId($render['id'])
+                ->setState($render['state'])
+                ->setStartedAt(new \DateTimeImmutable($render['started_at']))
+                ->setDateFinished(new \DateTimeImmutable($render['date_finished']))
+                ->setUrl($render['url'])
+                ->setError($render['error'])
+                ->setQuality($render['quality'])
+                ->setType($render['type'])
+                ->setProjectId($render['project_id']);
+        }
+
+        return $results;
+    }
+}

--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -20,6 +20,9 @@ class Project
     /** @var string */
     private $thumbnailPath;
 
+    /** @var Render[] */
+    private $renders;
+
     /** @var float */
     private $duration;
 
@@ -130,6 +133,30 @@ class Project
     public function setThumbnailPath(string $thumbnailPath): Project
     {
         $this->thumbnailPath = $thumbnailPath;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Renders
+     *
+     * @return Render[]
+     */
+    public function getRenders(): array
+    {
+        return $this->renders;
+    }
+
+    /**
+     * Sets the Renders
+     *
+     * @param Render[] $renders
+     *
+     * @return Project
+     */
+    public function setRenders(array $renders): Project
+    {
+        $this->renders = $renders;
 
         return $this;
     }

--- a/src/Model/Render.php
+++ b/src/Model/Render.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Moovly\SDK\Model;
+
+/**
+ * Class Render
+ * @package Moovly\SDK\Model
+ */
+class Render
+{
+    /** @var null|string */
+    private $id;
+
+    /** @var string */
+    private $state;
+
+    /** @var null|string */
+    private $url = null;
+
+    /** @var null|string */
+    private $quality = null;
+
+    /** @var string */
+    private $type;
+
+    /** @var null|string */
+    private $error = null;
+
+    /** @var null|string */
+    private $projectId = null;
+
+    /** @var \DateTimeImmutable */
+    private $startedAt;
+
+    /** @var null|\DateTimeImmutable */
+    private $dateFinished;
+
+    /**
+     * Returns the Id
+     *
+     * @return null|string
+     */
+    public function getId() : ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Sets the Id
+     *
+     * @param null|string $id
+     *
+     * @return Render
+     */
+    public function setId(?string $id) : Render
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Returns the State
+     *
+     * @return string
+     */
+    public function getState() : string
+    {
+        return $this->state;
+    }
+
+    /**
+     * Sets the State
+     *
+     * @param string $state
+     *
+     * @return Render
+     */
+    public function setState(string $state) : Render
+    {
+        $this->state = $state;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Url
+     *
+     * @return null|string
+     */
+    public function getUrl() : ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * Sets the Url
+     *
+     * @param null|string $url
+     *
+     * @return Render
+     */
+    public function setUrl(?string $url) : Render
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Quality
+     *
+     * @return null|string
+     */
+    public function getQuality() : ?string
+    {
+        return $this->quality;
+    }
+
+    /**
+     * Sets the Quality
+     *
+     * @param null|string $quality
+     *
+     * @return Render
+     */
+    public function setQuality(?string $quality) : Render
+    {
+        $this->quality = $quality;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Type
+     *
+     * @return string
+     */
+    public function getType() : string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets the Type
+     *
+     * @param string $type
+     *
+     * @return Render
+     */
+    public function setType(string $type) : Render
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Error
+     *
+     * @return null|string
+     */
+    public function getError() : ?string
+    {
+        return $this->error;
+    }
+
+    /**
+     * Sets the Error
+     *
+     * @param null|string $error
+     *
+     * @return Render
+     */
+    public function setError(?string $error) : Render
+    {
+        $this->error = $error;
+
+        return $this;
+    }
+
+    /**
+     * Returns the ProjectId
+     *
+     * @return null|string
+     */
+    public function getProjectId() : ?string
+    {
+        return $this->project_id;
+    }
+
+    /**
+     * Sets the ProjectId
+     *
+     * @param null|string $projectId
+     *
+     * @return Render
+     */
+    public function setProjectId(?string $projectId) : Render
+    {
+        $this->project_id = $projectId;
+
+        return $this;
+    }
+
+    /**
+     * Returns the StartedAt
+     *
+     * @return null|\DateTimeImmutable
+     */
+    public function getStartedAt(): \DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    /**
+     * Sets the StartedAt
+     *
+     * @param null|\DateTimeImmutable $startedAt
+     *
+     * @return Render
+     */
+    public function setStartedAt(?\DateTimeImmutable $startedAt): Render
+    {
+        $this->startedAt = $startedAt;
+
+        return $this;
+    }
+
+    /**
+     * Returns the DateFinished
+     *
+     * @return null|\DateTimeImmutable
+     */
+    public function getDateFinished(): \DateTimeImmutable
+    {
+        return $this->dateFinished;
+    }
+
+    /**
+     * Sets the DateFinished
+     *
+     * @param null|\DateTimeImmutable $dateFinished
+     *
+     * @return Render
+     */
+    public function setDateFinished(?\DateTimeImmutable $dateFinished): Render
+    {
+        $this->dateFinished = $dateFinished;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
When fetching projects from the API, the renders array is missing.

This PR adds the option to add this array to a project.