### PR TITLE
Improve moovly service create job

### DIFF
--- a/src/Model/Job.php
+++ b/src/Model/Job.php
@@ -12,7 +12,7 @@ class Job
     private $id;
 
     /** @var array */
-    private $options;
+    private $options = [];
 
     /** @var Template */
     private $template;

--- a/src/Service/MoovlyService.php
+++ b/src/Service/MoovlyService.php
@@ -282,13 +282,12 @@ final class MoovlyService
      * JobFactory and the ValueFactory to create this.
      *
      * @param Job   $job
-     * @param array $options
      *
      * @return Job
      *
      * @throws MoovlyException
      */
-    public function createJob(Job $job, array $options = []): Job
+    public function createJob(Job $job): Job
     {
         $validQualities = ['480p', '720p', '1080p'];
 
@@ -296,7 +295,7 @@ final class MoovlyService
             'quality'     => '480p',
             'create_moov' => false,
             'auto_render' => true,
-        ], $options);
+        ], $job->getOptions);
 
         if (!in_array($options['quality'], $validQualities)) {
             throw new BadRequestException(


### PR DESCRIPTION
There is no real need for an extra parameter as the options can fetched from the Job model.

This change would improve consistency as this approach is used further down in the function for other checks like the job values.